### PR TITLE
Fix InheritanceSpecifier and UsingForDeclaration node parsing

### DIFF
--- a/solidity_parser/parser.py
+++ b/solidity_parser/parser.py
@@ -130,13 +130,13 @@ class AstVisitor(SolidityVisitor):
             typename = self.visit(ctx.getChild(3))
 
         return Node(ctx=ctx,
-                    name="UsingForDeclaration",
+                    type="UsingForDeclaration",
                     typeName=typename,
                     libraryName=ctx.identifier().getText())
 
     def visitInheritanceSpecifier(self, ctx: SolidityParser.InheritanceSpecifierContext):
         return Node(ctx=ctx,
-                    name="InheritanceSpecifier",
+                    type="InheritanceSpecifier",
                     baseName=self.visit(ctx.userDefinedTypeName()),
                     arguments=self.visit(ctx.expression()))
 


### PR DESCRIPTION
Fixes #1, now `objectify` should work correctly for these two cases. It is also more consistent with other declarations.