### PR TITLE
Add typeName to the Parameter Nodes

### DIFF
--- a/solidity_parser/parser.py
+++ b/solidity_parser/parser.py
@@ -226,6 +226,7 @@ class AstVisitor(SolidityVisitor):
 
         return Node(ctx=ctx,
                     type="Parameter",
+                    typeName=self.visit(ctx.typeName()),
                     name=name,
                     storageLocation=storageLocation,
                     isStateVar=False,


### PR DESCRIPTION
This PR lets you get the `typeName` from a `Parameter` node.