### PR TITLE
fixed BooleanLiteral value

### DIFF
--- a/solidity_parser/parser.py
+++ b/solidity_parser/parser.py
@@ -639,7 +639,7 @@ class AstVisitor(SolidityVisitor):
         if ctx.BooleanLiteral():
             return Node(ctx=ctx,
                         type='BooleanLiteral',
-                        value=ctx.BooleanLiteral().getText() == 'True')
+                        value=ctx.BooleanLiteral().getText() == 'true')
 
         if ctx.HexLiteral():
             return Node(ctx=ctx,


### PR DESCRIPTION
This PR fixed to correct value of `BooleanLiteral`. 

The original code compared with `True` so that `true` value produced `false` value.

``` solidity
pragma solidity 0.5.11;
contract C {
  function f() public {
    bool a = true;
  }
}
```

``` json
"type": "VariableDeclarationStatement",
"variables": [
    {
        "type": "VariableDeclaration",
        "typeName": {
            "type": "ElementaryTypeName",
            "name": "bool",
            "loc": {
                "start": {
                    "line": 4,
                    "column": 4
                },
                "end": {
                    "line": 4,
                    "column": 4
                }
            }
        },
        "name": "a",
        "storageLocation": null,
        "loc": {
            "start": {
                "line": 4,
                "column": 4
            },
            "end": {
                "line": 4,
                "column": 9
            }
        }
    }
],
"initialValue": {
    "type": "BooleanLiteral",
    "value": false,
    "loc": {
        "start": {
            "line": 4,
            "column": 13
        },
        "end": {
            "line": 4,
            "column": 13
        }
    }
},
```