### PR TITLE
Various fixes/missing fields

### DIFF
--- a/solidity_parser/parser.py
+++ b/solidity_parser/parser.py
@@ -128,6 +128,7 @@ class AstVisitor(SolidityVisitor):
         return Node(ctx=ctx,
                     type="TypeDefinition",
                     typeKeyword=ctx.TypeKeyword().getText(),
+                    name=ctx.identifier().getText(),
                     elementaryTypeName=self.visit(ctx.elementaryTypeName()))
 
 
@@ -467,7 +468,9 @@ class AstVisitor(SolidityVisitor):
                     type='ModifierDefinition',
                     name=ctx.identifier().getText(),
                     parameters=parameters,
-                    body=self.visit(ctx.block()))
+                    body=self.visit(ctx.block()),
+                    isVirtual=ctx.VirtualKeyword() is not None,
+                    isOverride=ctx.overrideSpecifier() is not None)
 
     def visitStatement(self, ctx):
         return self.visit(ctx.getChild(0))
@@ -484,6 +487,13 @@ class AstVisitor(SolidityVisitor):
         return Node(ctx=ctx,
                     type='RevertStatement',
                     functionCall=self.visit(ctx.functionCall()))
+
+    def _index_of_child(self, ctx, child):
+        for i in range(0, len(ctx.children)):
+            if ctx.getChild(i).getText() == child:
+                return i
+
+        return None
 
     def visitExpression(self, ctx):
 
@@ -599,11 +609,27 @@ class AstVisitor(SolidityVisitor):
                             arguments=args,
                             names=names)
 
-            if ctx.getChild(1).getText() == '[' and ctx.getChild(3).getText() == ']':
+            if (ctx.getChild(1).getText() == '[' and
+                    ctx.getChild(2).getText() != ':' and
+                    ctx.getChild(3).getText() == ']'):
                 return Node(ctx=ctx,
                             type='IndexAccess',
                             base=self.visit(ctx.getChild(0)),
                             index=self.visit(ctx.getChild(2)))
+
+            if ctx.getChild(1).getText() == '{' and ctx.getChild(3).getText() == '}':
+                args = []
+                names = []
+
+                for nameValue in ctx.nameValueList().nameValue():
+                    args.append(self.visit(nameValue.expression()))
+                    names.append(nameValue.identifier().getText())
+
+                return Node(ctx=ctx,
+                            type='FunctionCallOptions',
+                            expression=self.visit(ctx.getChild(0)),
+                            arguments=args,
+                            names=names)
 
         elif children_length == 5:
             # ternary
@@ -613,6 +639,30 @@ class AstVisitor(SolidityVisitor):
                             condition=self.visit(ctx.getChild(0)),
                             TrueExpression=self.visit(ctx.getChild(2)),
                             FalseExpression=self.visit(ctx.getChild(4)))
+
+        if 4 <= children_length <= 6 and ctx.getChild(1).getText() == '[':
+            left_bracket_index = self._index_of_child(ctx, '[')
+            colon_index = self._index_of_child(ctx, ':')
+            right_bracket_index = self._index_of_child(ctx, ']')
+
+            if (left_bracket_index == 1 and
+                    left_bracket_index < colon_index <= left_bracket_index + 2 and
+                    colon_index < right_bracket_index <= colon_index + 2 and
+                    right_bracket_index == children_length - 1):
+                indexLower = None
+                indexUpper = None
+
+                if colon_index == left_bracket_index + 2:
+                    indexLower = self.visit(ctx.getChild(left_bracket_index + 1))
+
+                if right_bracket_index == colon_index + 2:
+                    indexUpper = self.visit(ctx.getChild(colon_index + 1))
+
+                return Node(ctx=ctx,
+                            type='IndexRangeAccess',
+                            base=self.visit(ctx.getChild(0)),
+                            indexLower=indexLower,
+                            indexUpper=indexUpper)
 
         return self.visit(list(ctx.getChildren()))
 
@@ -741,16 +791,16 @@ class AstVisitor(SolidityVisitor):
     def visitVariableDeclarationList(self, ctx: SolidityParser.VariableDeclarationListContext):
         result = []
         for decl in self._mapCommasToNulls(ctx.children):
-            if decl == None:
-                return None
-
-            result.append(self._createNode(ctx=ctx,
-                                           type='VariableDeclaration',
-                                           name=decl.identifier().getText(),
-                                           typeName=self.visit(decl.typeName()),
-                                           isStateVar=False,
-                                           isIndexed=False,
-                                           decl=decl))
+            if decl is None:
+                result.append(None)
+            else:
+                result.append(self._createNode(ctx=ctx,
+                                               type='VariableDeclaration',
+                                               name=decl.identifier().getText(),
+                                               typeName=self.visit(decl.typeName()),
+                                               isStateVar=False,
+                                               isIndexed=False,
+                                               decl=decl))
 
         return result
 
@@ -845,9 +895,16 @@ class AstVisitor(SolidityVisitor):
         return self.visit(ctx.getChild(0))
 
     def visitAssemblyMember(self, ctx):
+        identifier = ctx.identifier()
+
+        if isinstance(identifier, list):
+            name = [n.getText() for n in identifier]
+        else:
+            name = identifier.getText()
+
         return Node(ctx=ctx,
                     type='AssemblyMember',
-                    name=ctx.identifier().getText())
+                    name=name)
 
     def visitAssemblyCall(self, ctx):
         functionName = ctx.getChild(0).getText()
@@ -935,8 +992,10 @@ class AstVisitor(SolidityVisitor):
 
         if names.identifier():
             names = [self.visit(names.identifier())]
-        else:
+        elif names.assemblyIdentifierList():
             names = self.visit(names.assemblyIdentifierList().identifier())
+        else:
+            names = self.visit(names.assemblyMember())
 
         return Node(ctx=ctx,
                     type='AssemblyAssignment',
@@ -1016,7 +1075,17 @@ class AstVisitor(SolidityVisitor):
                     name=ctx.getText())
 
     def visitReturnStatement(self, ctx):
-        return self.visit(ctx.expression())
+        return Node(ctx=ctx,
+                    type="ReturnStatement",
+                    expression=self.visit(ctx.expression()))
+
+    def visitBreakStatement(self, ctx):
+        return Node(ctx=ctx,
+                    type="BreakStatement")
+
+    def visitContinueStatement(self, ctx):
+        return Node(ctx=ctx,
+                    type="ContinueStatement")
 
     def visitTerminal(self, ctx):
         return ctx.getText()


### PR DESCRIPTION
Just an informal collection of problems I encountered and fixed locally.
Sorry for not presenting it in a more organized way.
Feel free to modify/integrate it however you like.

- Added `name` field to `TypeDefinition` nodes
- Added `isVirtual` and `isOverride` fields to `ModifierDefinition` nodes
- Added support for parsing for `FunctionCallOptions` (of the form `fn{key=value}(args)`)
- Added support for parsing `IndexRangeAccess`es (of the form `array[from:to]`)
- Added proper nodes for the `ReturnStatement`, `BreakStatement`, and `ContinueStatement` (which were previously rendered as the return expression or just `';'` for expression-less statements)
- Fixed parser discarding all variable declarations in a variable declaration list if one is `None`
- Fixed parser failing if an assembly member's identifier is a list (not quite sure where that was a problem TBH)
- Fixed parser failing an assembly assignment to a member

I added some more fixes with commit eb548d1 on 2022-05-12:

- Added `isDeclaredImmutable` to variable declaration, similar to `isDeclaredConst`
- Rendered omitted loop expressions in for loops as `None` instead of an `ExpressionStatement` with `None` as its expression
- Added `storageLocation` field to variable declarations inside a variable declaration list