### PR TITLE
Fix missing ident with omitted fields in tuple assignment 

### DIFF
--- a/solidity_parser/parser.py
+++ b/solidity_parser/parser.py
@@ -744,9 +744,11 @@ class AstVisitor(SolidityVisitor):
             if decl == None:
                 return None
 
+            ident = decl.identifier()
+            name = ident and ident.getText() or '_'
             result.append(self._createNode(ctx=ctx,
                                            type='VariableDeclaration',
-                                           name=decl.identifier().getText(),
+                                           name=name,
                                            typeName=self.visit(decl.typeName()),
                                            isStateVar=False,
                                            isIndexed=False,


### PR DESCRIPTION
The parser will fail if we omit fields in tuple assignment, for example with the following contract `Simple.sol`, 

```solidity
pragma solidity ^0.8.0;
contract Simple {
    function withdraw(uint _amount) public {
        if (_amount > 1000){
            (bool result,) = msg.sender.call{value:_amount}("");
            require(result);
        }
    }
}
```

`python -m solidity_parser outline Simple.sol` fails with `Exception: unrecognized expression` 

This PR fixes the error by checking the existance of `identifier` before getting the text name from it.
